### PR TITLE
Add an output format option that forms as a markdown task list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,30 @@ Run the tool with the following command:
 ./stale-flag-detector [options]
 
 Options:
+
 - --exclude-potentially-stale-flags: Exclude potentially stale flags from the results
-- --output-regex: Output the stale flags as a grep-compatible regex
+- --output-format: Specifies the output format (defaults to "markdown-unordered_list")
+  - "markdown-unordered_list": Output as Markdown unordered list
+  - "markdown-task_list": Output as Markdown task list
+  - "regex": Output as a grep-compatible regex
 
 ## Example
 
-./stale-flag-detector --output-regex
-
-This will output a regex of all stale flags, which can be used with grep to search your codebase for usage of these flags.
-
 ```bash
-% ./stale-flag-detector --output-regex
+# Output as Markdown unordered list (default)
+% ./stale-flag-detector
+Stale flags:
+- unleash-ai-example-stale
+- another-stale-flag
+
+# Output as Markdown task list
+% ./stale-flag-detector --output-format=markdown-task_list
+Stale flags:
+- [ ] unleash-ai-example-stale
+- [ ] another-stale-flag
+
+# Output as regex for grep
+% ./stale-flag-detector --output-format=regex
 (unleash-ai-example-stale|another-stale-flag)
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Run the tool with the following command:
 Options:
 
 - --exclude-potentially-stale-flags: Exclude potentially stale flags from the results
-- --output-format: Specifies the output format (defaults to "markdown-unordered_list")
-  - "markdown-unordered_list": Output as Markdown unordered list
-  - "markdown-task_list": Output as Markdown task list
+- --output-format: Specifies the output format (defaults to "markdown-unordered-list")
+  - "markdown-unordered-list": Output as Markdown unordered list
+  - "markdown-task-list": Output as Markdown task list
   - "regex": Output as a grep-compatible regex
 
 ## Example
@@ -81,7 +81,7 @@ Stale flags:
 - another-stale-flag
 
 # Output as Markdown task list
-% ./stale-flag-detector --output-format=markdown-task_list
+% ./stale-flag-detector --output-format=markdown-task-list
 Stale flags:
 - [ ] unleash-ai-example-stale
 - [ ] another-stale-flag

--- a/main.go
+++ b/main.go
@@ -18,8 +18,13 @@ func main() {
 	}
 
 	excludePotentiallyStaleFlags := flag.Bool("exclude-potentially-stale-flags", false, "Exclude potentially stale flags")
-	outputRegex := flag.Bool("output-regex", false, "Output flags as a grep-compatible regex")
+	outputFormat := flag.String("output-format", string(OutputFormatMarkdownUnorderedList), "Specifies the output format")
 	flag.Parse()
+
+	if err := validateOutputFormatFlag(*outputFormat); err != nil {
+		fmt.Printf("Error loading config: %v\n", err)
+		os.Exit(1)
+	}
 
 	client := unleash.NewClient(cfg.UnleashAPIEndpoint, cfg.UnleashAPIToken, cfg.ProjectID, cfg)
 	staleFlags, err := client.GetStaleFlags(*excludePotentiallyStaleFlags)
@@ -33,13 +38,20 @@ func main() {
 		return
 	}
 
-	if *outputRegex {
-		regex := strings.Join(staleFlags, "|")
-		fmt.Printf("(%s)\n", regex)
-	} else {
+	switch *outputFormat {
+	case OutputFormatMarkdownUnorderedList:
 		fmt.Println("Stale flags:")
 		for _, flag := range staleFlags {
 			fmt.Printf("- %s\n", flag)
 		}
+	case OutputFormatMarkdownTaskList:
+		fmt.Println("Stale flags:")
+		for _, flag := range staleFlags {
+			fmt.Printf("- [ ] %s\n", flag)
+		}
+	case OutputFormatRegex:
+		regex := strings.Join(staleFlags, "|")
+		fmt.Printf("(%s)\n", regex)
+		// we already validated the flag format, so don't neet default clause
 	}
 }

--- a/output_format.go
+++ b/output_format.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	OutputFormatMarkdownUnorderedList = "markdown-unordered_list"
+	OutputFormatMarkdownTaskList      = "markdown-task_list"
+	OutputFormatRegex                 = "regex"
+)
+
+func validateOutputFormatFlag(f string) error {
+	formatCatalog := []string{
+		OutputFormatMarkdownUnorderedList,
+		OutputFormatMarkdownTaskList,
+		OutputFormatRegex,
+	}
+	isValidFlag := false
+
+	for _, expected := range formatCatalog {
+		isValidFlag = f == expected
+		if isValidFlag {
+			break
+		}
+	}
+	if !isValidFlag {
+		return fmt.Errorf("-output-format flag is invalid format; (%s) required but got %s", strings.Join(formatCatalog, "|"), f)
+	}
+
+	return nil
+}

--- a/output_format.go
+++ b/output_format.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	OutputFormatMarkdownUnorderedList = "markdown-unordered_list"
-	OutputFormatMarkdownTaskList      = "markdown-task_list"
+	OutputFormatMarkdownUnorderedList = "markdown-unordered-list"
+	OutputFormatMarkdownTaskList      = "markdown-task-list"
 	OutputFormatRegex                 = "regex"
 )
 


### PR DESCRIPTION
Add an output format option that generates a Markdown task list.  
For greater flexibility, remove the `-output-regex` flag and introduce the `-output-format` flag, which supports multiple output format variants.

